### PR TITLE
refactor: use pipe operators where applicable.

### DIFF
--- a/modules/nixos/nix/default.nix
+++ b/modules/nixos/nix/default.nix
@@ -28,7 +28,12 @@ in {
         "ca-derivations"
       ];
 
-      trusted-users = ["root" "@wheel"];
+      extra-experimental-features = ["pipe-operator"];
+      trusted-users = [
+        "root"
+        "@wheel"
+      ];
+
       connect-timeout = 5; # Timeout after 5 seconds.
       cores = 0;
       auto-optimise-store = true;


### PR DESCRIPTION
This PR will track the status of the integration of `pipe-operator` in other tools since it currently isn't recognized by `alejandra` or even the Neovim LSP (`nixd`).

> [!CAUTION]
> This introduces unstable changes in the form of the `pipe-operator`
> experimental feature.  
> Currently this fails basic evaluation of most tools, including the CI
> pipeline, so it'll remain unmerged for now.
