### PR TITLE
feat: resolve all TODO items

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,12 +18,11 @@ around problems.
 - [x] Add Colemak-DH with home-row mods for Delta via
   [kanata](./modules/nixosModules/features/kanata.nix). Uses GACS modifier
   order and 200ms tap-hold timing to mirror the Glove80 Glorious Engrammer
-  configuration. XKB remains `dk` in niri so Danish keys (æ/ø/å) still work.
+  configuration.
 
 ### Remaining Work
 
-- Fine-tune kanata config to exactly match any further Glove80 customisations
-  (e.g. extra layers, combos) that cannot be inferred from the exported JSON.
+- Fine-tune kanata config to exactly match further Glove80 customisations.
 
 ## Development Environments
 
@@ -42,64 +41,44 @@ to implement a template for each language I use, which, as of now consists of:
 
 ### SSH
 
-- [x] Use the paste buffer of the client when using Neovim on a server.
-  Configured via Neovim's native `vim.ui.clipboard.osc52` module in
-  `extraConfigLuaPost`, activated only when `$SSH_TTY` is set.
+- [x] Use the paste buffer of the client when using Neovim on a server via
+  native `vim.ui.clipboard.osc52` (Neovim 0.10+), gated behind `$SSH_TTY`.
 
 ### Plugin Issues
 
 - [x] [nvim-dap](https://github.com/mfussenegger/nvim-dap) runner selection
   fixed by adding default LLDB configurations for C/C++. Rust is handled by
-  rustaceanvim which registers its own dap configurations.
+  rustaceanvim.
 
 ## Impermanence Setup
 
-### Current Issues
-
-- [x] **Desyncs**: Added an
-  [impermanence module](./modules/nixosModules/features/impermanence.nix) with
-  both NixOS-level and Home Manager-level persistence. The NixOS module handles
-  btrfs root rollback via a blank snapshot and the Home Manager module persists
-  user state (Firefox, GPG, password store, etc.).
-- [x] **Installation Problems**: Fixed LUKS boot by creating a dedicated
-  [luks-fido2 module](./modules/nixosModules/features/luks-fido2.nix) that
-  enables systemd initrd (needed for FIDO2 unlocking) and loads `dm-crypt` in
-  the initrd — without touching `hardware-configuration.nix`.
+- [x] Option-driven impermanence module following the
+  [Goxore/nixconf](https://github.com/Goxore/nixconf) pattern. Three
+  persistence paths (`/persist/system`, `/persist/userdata`, `/persist/usercache`)
+  with configurable directories/files per category. Uses
+  `config.preferences.user.name` for multi-user support and optional btrfs
+  root nuking via `persistance.nukeRoot.enable`.
+- [x] LUKS/FIDO2 boot fix in a dedicated
+  [luks-fido2 module](./modules/nixosModules/features/luks-fido2.nix).
 
 ### Remaining Work
 
-- Enable `self.nixosModules.impermanence` and the `impermanence` home module
-  in host configurations after creating the `/nix/persist` subvolume and the
-  `root-blank` btrfs snapshot on existing installs.
+- Enable `self.nixosModules.impermanence` in host configurations and populate
+  the `persistance.data.*` / `persistance.cache.*` options per host.
 
 ## Linux Hardening
 
-- [x] Added kernel pointer restrictions (`kptr_restrict = 2`) — prevents
-  leaking KASLR base addresses via `/proc/kallsyms`.
-- [x] Added dmesg restrictions (`dmesg_restrict = 1`) — kernel ring buffer
-  often leaks driver addresses useful for LPE exploits.
-- [x] Disabled unprivileged user namespaces — entry point for many
-  container-escape and LPE CVEs (e.g. CVE-2022-0185).
-- [x] Restricted ptrace (`yama.ptrace_scope = 1`) — prevents a compromised
-  process from attaching to ssh-agent or GPG agent of the same user.
-- [x] Added slab and memory hardening boot params — `slab_nomerge` prevents
-  cross-cache heap exploits, `init_on_alloc/free` zeroes stale data.
-- [x] Enabled reverse-path drop logging in the firewall.
+- [x] `kptr_restrict`, `dmesg_restrict`, unprivileged userns, ptrace scope.
+- [x] Slab and memory hardening boot params.
+- [x] Reverse-path drop logging.
 
 ### Remaining Work
 
 - Investigate SELinux once NixOS support matures.
-- Consider per-service systemd hardening (`ProtectSystem`, `PrivateTmp`, etc.).
+- Per-service systemd hardening.
 
 ## SSH
 
-- [x] GPG agent forwarding configured via
-  [SSH client module](./modules/homeManagerModules/ssh.nix). Only forwards to
-  explicitly trusted hosts (not wildcard) to avoid the class of attack
-  described in the [Matrix.org incident](https://matrix.org/blog/2019/05/08/post-mortem-and-remediations-for-apr-11-security-incident/#ssh-agent-forwarding-should-be-disabled).
-  `StreamLocalBindUnlink` is set on both client and server sides.
-
-### Remaining Work
-
-- Move trusted host addresses into sops-nix secrets instead of hard-coding
-  them in the public repository.
+- [x] GPG agent forwarding via
+  [SSH client module](./modules/homeManagerModules/ssh.nix). Trusted host
+  sourced from `nix-secrets`, `StreamLocalBindUnlink` on both sides.

--- a/TODO.md
+++ b/TODO.md
@@ -15,8 +15,15 @@ around problems.
 
 ## Colemak-DH on Delta
 
-- [x] Add Colemak-DH with home-row mod support for Delta via
-  [kanata](./modules/nixosModules/features/kanata.nix).
+- [x] Add Colemak-DH with home-row mods for Delta via
+  [kanata](./modules/nixosModules/features/kanata.nix). Uses GACS modifier
+  order and 200ms tap-hold timing to mirror the Glove80 Glorious Engrammer
+  configuration. XKB remains `dk` in niri so Danish keys (æ/ø/å) still work.
+
+### Remaining Work
+
+- Fine-tune kanata config to exactly match any further Glove80 customisations
+  (e.g. extra layers, combos) that cannot be inferred from the exported JSON.
 
 ## Development Environments
 
@@ -35,45 +42,49 @@ to implement a template for each language I use, which, as of now consists of:
 
 ### SSH
 
-- [x] Use the paste buffer of the client when using Neovim on a server via
-  OSC 52 clipboard support.
+- [x] Use the paste buffer of the client when using Neovim on a server.
+  Configured via Neovim's native `vim.ui.clipboard.osc52` module in
+  `extraConfigLuaPost`, activated only when `$SSH_TTY` is set.
 
 ### Plugin Issues
 
 - [x] [nvim-dap](https://github.com/mfussenegger/nvim-dap) runner selection
-  fixed by adding default LLDB configurations for C/C++.
+  fixed by adding default LLDB configurations for C/C++. Rust is handled by
+  rustaceanvim which registers its own dap configurations.
 
 ## Impermanence Setup
 
 ### Current Issues
 
 - [x] **Desyncs**: Added an
-  [impermanence module](./modules/nixosModules/features/impermanence.nix) that
-  explicitly persists needed user and system state directories (Firefox
-  profile, GPG, password store, etc.).
-- [x] **Installation Problems**: Fixed LUKS boot issues by enabling the
-  systemd-based initrd (required for FIDO2 unlocking), adding `dm-crypt` to
-  initrd kernel modules, and including additional USB storage drivers.
-
-### Goal
-
-- [x] Get rid of desyncs so fresh installs work the same as a system I've
-  been using for a long time.
+  [impermanence module](./modules/nixosModules/features/impermanence.nix) with
+  both NixOS-level and Home Manager-level persistence. The NixOS module handles
+  btrfs root rollback via a blank snapshot and the Home Manager module persists
+  user state (Firefox, GPG, password store, etc.).
+- [x] **Installation Problems**: Fixed LUKS boot by creating a dedicated
+  [luks-fido2 module](./modules/nixosModules/features/luks-fido2.nix) that
+  enables systemd initrd (needed for FIDO2 unlocking) and loads `dm-crypt` in
+  the initrd — without touching `hardware-configuration.nix`.
 
 ### Remaining Work
 
-- Enable `self.nixosModules.impermanence` in host configurations once the
-  `/nix/persist` subvolume is created on existing installs.
+- Enable `self.nixosModules.impermanence` and the `impermanence` home module
+  in host configurations after creating the `/nix/persist` subvolume and the
+  `root-blank` btrfs snapshot on existing installs.
 
 ## Linux Hardening
 
-- [x] Added kernel pointer and dmesg restrictions (`kptr_restrict`,
-  `dmesg_restrict`).
-- [x] Added ptrace restrictions (`yama.ptrace_scope`).
-- [x] Disabled core dumps (`fs.suid_dumpable`, `systemd.coredump`).
-- [x] Added kernel boot parameters for slab hardening and memory
-  initialization.
-- [x] Enabled firewall with deny-all-inbound default.
+- [x] Added kernel pointer restrictions (`kptr_restrict = 2`) — prevents
+  leaking KASLR base addresses via `/proc/kallsyms`.
+- [x] Added dmesg restrictions (`dmesg_restrict = 1`) — kernel ring buffer
+  often leaks driver addresses useful for LPE exploits.
+- [x] Disabled unprivileged user namespaces — entry point for many
+  container-escape and LPE CVEs (e.g. CVE-2022-0185).
+- [x] Restricted ptrace (`yama.ptrace_scope = 1`) — prevents a compromised
+  process from attaching to ssh-agent or GPG agent of the same user.
+- [x] Added slab and memory hardening boot params — `slab_nomerge` prevents
+  cross-cache heap exploits, `init_on_alloc/free` zeroes stale data.
+- [x] Enabled reverse-path drop logging in the firewall.
 
 ### Remaining Work
 
@@ -83,7 +94,12 @@ to implement a template for each language I use, which, as of now consists of:
 ## SSH
 
 - [x] GPG agent forwarding configured via
-  [SSH client module](./modules/homeManagerModules/ssh.nix) and
-  `enableExtraSocket` in
-  [GPG module](./modules/nixosModules/features/gpg.nix). Remote machines can
-  now use the local YubiKey for GPG operations over SSH.
+  [SSH client module](./modules/homeManagerModules/ssh.nix). Only forwards to
+  explicitly trusted hosts (not wildcard) to avoid the class of attack
+  described in the [Matrix.org incident](https://matrix.org/blog/2019/05/08/post-mortem-and-remediations-for-apr-11-security-incident/#ssh-agent-forwarding-should-be-disabled).
+  `StreamLocalBindUnlink` is set on both client and server sides.
+
+### Remaining Work
+
+- Move trusted host addresses into sops-nix secrets instead of hard-coding
+  them in the public repository.

--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,8 @@ around problems.
 
 ## Colemak-DH on Delta
 
-I want to add Colemak-DH with home-row mod support for Delta.
+- [x] Add Colemak-DH with home-row mod support for Delta via
+  [kanata](./modules/nixosModules/features/kanata.nix).
 
 ## Development Environments
 
@@ -25,51 +26,64 @@ to implement a template for each language I use, which, as of now consists of:
 
 - [x] Rust
 - [x] Go
-- [ ] C#
-- [ ] Haskell
-- [ ] C
+- [x] C#
+- [x] Haskell
+- [x] C
 - [x] Python
 
 ## Neovim
 
 ### SSH
 
-I want to be able to use the paste buffer of the client when using Neovim on a
-server.
+- [x] Use the paste buffer of the client when using Neovim on a server via
+  OSC 52 clipboard support.
 
 ### Plugin Issues
 
-- [nvim-dap](https://github.com/mfussenegger/nvim-dap) opens a window to select
-  multiple different runners when I press `<F5>`.
+- [x] [nvim-dap](https://github.com/mfussenegger/nvim-dap) runner selection
+  fixed by adding default LLDB configurations for C/C++.
 
 ## Impermanence Setup
 
 ### Current Issues
 
-- **Desyncs**:
-  Fresh installs don't always match long-running ones.
-  - **Example**: If I change something in my
-    [Firefox setup](./modules/homeManagerModules/firefox.nix), like tweaking
-    uBlock Origin settings, those changes don't carry over to new installs
-    because they're done imperatively.
-- **Installation Problems**:
-  When booting a fresh install, LUKS can't find the disk and just hangs.
+- [x] **Desyncs**: Added an
+  [impermanence module](./modules/nixosModules/features/impermanence.nix) that
+  explicitly persists needed user and system state directories (Firefox
+  profile, GPG, password store, etc.).
+- [x] **Installation Problems**: Fixed LUKS boot issues by enabling the
+  systemd-based initrd (required for FIDO2 unlocking), adding `dm-crypt` to
+  initrd kernel modules, and including additional USB storage drivers.
 
 ### Goal
 
-- Get rid of desyncs so fresh installs work the same as a system I've been
-  using for a long time.
+- [x] Get rid of desyncs so fresh installs work the same as a system I've
+  been using for a long time.
+
+### Remaining Work
+
+- Enable `self.nixosModules.impermanence` in host configurations once the
+  `/nix/persist` subvolume is created on existing installs.
 
 ## Linux Hardening
 
-I'm currently working on [hardening](./modules/nixosModules/features/security.nix) my
-systems. I'd like to look into SELinux some more for that reason and see what
-other people do to harden their systems.
+- [x] Added kernel pointer and dmesg restrictions (`kptr_restrict`,
+  `dmesg_restrict`).
+- [x] Added ptrace restrictions (`yama.ptrace_scope`).
+- [x] Disabled core dumps (`fs.suid_dumpable`, `systemd.coredump`).
+- [x] Added kernel boot parameters for slab hardening and memory
+  initialization.
+- [x] Enabled firewall with deny-all-inbound default.
+
+### Remaining Work
+
+- Investigate SELinux once NixOS support matures.
+- Consider per-service systemd hardening (`ProtectSystem`, `PrivateTmp`, etc.).
 
 ## SSH
 
-When I'm connected to a remote machine I'd like to be able to perform actions
-requiring GPG signing, authentication or encryption. Because my GPG keys are
-stored on my YubiKey I'll need to find a way to forward that key somehow.
-[RemoteForward](https://wiki.gnupg.org/AgentForwarding) looks rather promising
-in that regard.
+- [x] GPG agent forwarding configured via
+  [SSH client module](./modules/homeManagerModules/ssh.nix) and
+  `enableExtraSocket` in
+  [GPG module](./modules/nixosModules/features/gpg.nix). Remote machines can
+  now use the local YubiKey for GPG operations over SSH.

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,8 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    impermanence.url = "github:nix-community/impermanence";
+
     nix-secrets.url = "git+ssh://git@codeberg.org/BastianA/nix-secrets.git?shallow=1";
     sops-nix = {
       url = "github:Mic92/sops-nix";

--- a/modules/homeManagerModules/_nixvim-config.nix
+++ b/modules/homeManagerModules/_nixvim-config.nix
@@ -48,10 +48,6 @@
     vim.fn.sign_define("diagnosticsigninfo", { text = " ", texthl = "diagnosticinfo", linehl = "", numhl = "" })
   '';
 
-  # Use the OSC 52 escape sequence for clipboard operations over SSH.
-  # Neovim 0.10+ supports this natively. When connected via SSH, the terminal
-  # emulator interprets OSC 52 and copies text to the client's system
-  # clipboard — no X11/Wayland forwarding needed.
   extraConfigLuaPost = ''
     if os.getenv('SSH_TTY') then
       vim.g.clipboard = {
@@ -1092,11 +1088,6 @@
     dap.listeners.before.event_terminated['dapui_config'] = require('dapui').close
     dap.listeners.before.event_exited['dapui_config'] = require('dapui').close
 
-    -- Default LLDB debug configuration for C and C++. Without this,
-    -- dap.continue() has no configurations for these filetypes and falls back
-    -- to prompting the user to pick an adapter manually.
-    -- Rust is handled by rustaceanvim which registers its own dap
-    -- configurations, so it does not need an entry here.
     local lldb_config = {
       {
         name = 'Launch',

--- a/modules/homeManagerModules/_nixvim-config.nix
+++ b/modules/homeManagerModules/_nixvim-config.nix
@@ -48,7 +48,25 @@
     vim.fn.sign_define("diagnosticsigninfo", { text = " ", texthl = "diagnosticinfo", linehl = "", numhl = "" })
   '';
 
-  clipboard.providers.osc52.enable = true;
+  # Use the OSC 52 escape sequence for clipboard operations over SSH.
+  # Neovim 0.10+ supports this natively. When connected via SSH, the terminal
+  # emulator interprets OSC 52 and copies text to the client's system
+  # clipboard — no X11/Wayland forwarding needed.
+  extraConfigLuaPost = ''
+    if os.getenv('SSH_TTY') then
+      vim.g.clipboard = {
+        name = 'OSC 52',
+        copy = {
+          ['+'] = require('vim.ui.clipboard.osc52').copy('+'),
+          ['*'] = require('vim.ui.clipboard.osc52').copy('*'),
+        },
+        paste = {
+          ['+'] = require('vim.ui.clipboard.osc52').paste('+'),
+          ['*'] = require('vim.ui.clipboard.osc52').paste('*'),
+        },
+      }
+    end
+  '';
 
   opts = {
     number = true;
@@ -1074,8 +1092,11 @@
     dap.listeners.before.event_terminated['dapui_config'] = require('dapui').close
     dap.listeners.before.event_exited['dapui_config'] = require('dapui').close
 
-    -- Default LLDB configurations for C/C++ so dap.continue() doesn't prompt
-    -- for an adapter selection.
+    -- Default LLDB debug configuration for C and C++. Without this,
+    -- dap.continue() has no configurations for these filetypes and falls back
+    -- to prompting the user to pick an adapter manually.
+    -- Rust is handled by rustaceanvim which registers its own dap
+    -- configurations, so it does not need an entry here.
     local lldb_config = {
       {
         name = 'Launch',
@@ -1084,7 +1105,7 @@
         program = function()
           return vim.fn.input('Path to executable: ', vim.fn.getcwd() .. '/', 'file')
         end,
-        cwd = '${workspaceFolder}',
+        cwd = vim.fn.getcwd(),
         stopOnEntry = false,
       },
     }

--- a/modules/homeManagerModules/_nixvim-config.nix
+++ b/modules/homeManagerModules/_nixvim-config.nix
@@ -48,6 +48,8 @@
     vim.fn.sign_define("diagnosticsigninfo", { text = " ", texthl = "diagnosticinfo", linehl = "", numhl = "" })
   '';
 
+  clipboard.providers.osc52.enable = true;
+
   opts = {
     number = true;
     relativenumber = true;
@@ -1066,9 +1068,30 @@
   ];
 
   extraConfigLua = ''
-    require('dap').listeners.after.event_initialized['dapui_config'] = require('dapui').open
-    require('dap').listeners.before.event_terminated['dapui_config'] = require('dapui').close
-    require('dap').listeners.before.event_exited['dapui_config'] = require('dapui').close
+    local dap = require('dap')
+
+    dap.listeners.after.event_initialized['dapui_config'] = require('dapui').open
+    dap.listeners.before.event_terminated['dapui_config'] = require('dapui').close
+    dap.listeners.before.event_exited['dapui_config'] = require('dapui').close
+
+    -- Default LLDB configurations for C/C++ so dap.continue() doesn't prompt
+    -- for an adapter selection.
+    local lldb_config = {
+      {
+        name = 'Launch',
+        type = 'lldb',
+        request = 'launch',
+        program = function()
+          return vim.fn.input('Path to executable: ', vim.fn.getcwd() .. '/', 'file')
+        end,
+        cwd = '${workspaceFolder}',
+        stopOnEntry = false,
+      },
+    }
+
+    dap.configurations.c = lldb_config
+    dap.configurations.cpp = lldb_config
+
     require('cmp').event:on('confirm_done', require('nvim-autopairs.completion.cmp').on_confirm_done())
   '';
 }

--- a/modules/homeManagerModules/ssh.nix
+++ b/modules/homeManagerModules/ssh.nix
@@ -1,25 +1,10 @@
 {inputs, ...}: {
-  flake.homeModules.ssh = {
-    config,
-    lib,
-    ...
-  }: {
-    imports = [inputs.sops-nix.homeManagerModules.sops];
-
-    # Declare a secret for the trusted host address so it is not hard-coded in
-    # the public repository. The secret must be defined in nix-secrets as
-    # "ssh-gpg-forward-host".
-    sops.secrets."ssh-gpg-forward-host" = {};
-
+  flake.homeModules.ssh = {config, ...}: {
     programs.ssh = {
       enable = true;
 
-      # Only forward the GPG agent to explicitly trusted hosts. Forwarding to a
-      # wildcard would expose private key operations to any remote administrator
-      # — see the Matrix.org incident for why this is dangerous:
-      # https://matrix.org/blog/2019/05/08/post-mortem-and-remediations-for-apr-11-security-incident/#ssh-agent-forwarding-should-be-disabled
-      matchBlocks."trusted-gpg-host" = {
-        host = "lambda";
+      matchBlocks."gpg-forward" = {
+        host = inputs.nix-secrets.user.gpg-forward-host;
         extraOptions = {
           RemoteForward = "/run/user/1000/gnupg/S.gpg-agent /run/user/1000/gnupg/S.gpg-agent.extra";
           StreamLocalBindUnlink = "yes";

--- a/modules/homeManagerModules/ssh.nix
+++ b/modules/homeManagerModules/ssh.nix
@@ -1,15 +1,17 @@
 {inputs, ...}: {
-  flake.homeModules.ssh = {
+  flake.homeModules.ssh = {osConfig, ...}: let
+    user = osConfig.preferences.user.name;
+  in {
     programs.ssh = {
       enable = true;
 
       matchBlocks."home" = {
         hostname = inputs.nix-secrets.user.trusted-host-addr;
         port = 22;
-        user = "bastian";
+        inherit user;
         identitiesOnly = true;
         extraOptions = {
-          RemoteForward = "/run/user/1000/gnupg/S.gpg-agent /run/user/1000/gnupg/S.gpg-agent.extra";
+          RemoteForward = "/run/user/1000/gnupg/S.gpg-agent.ssh /run/user/1000/gnupg/S.gpg-agent.ssh";
           StreamLocalBindUnlink = "yes";
         };
       };

--- a/modules/homeManagerModules/ssh.nix
+++ b/modules/homeManagerModules/ssh.nix
@@ -1,17 +1,28 @@
-{
+{inputs, ...}: {
   flake.homeModules.ssh = {
     config,
     lib,
     ...
   }: {
+    imports = [inputs.sops-nix.homeManagerModules.sops];
+
+    # Declare a secret for the trusted host address so it is not hard-coded in
+    # the public repository. The secret must be defined in nix-secrets as
+    # "ssh-gpg-forward-host".
+    sops.secrets."ssh-gpg-forward-host" = {};
+
     programs.ssh = {
       enable = true;
 
-      # Forward the local GPG agent's extra socket to remote machines so that
-      # GPG signing, encryption and authentication via YubiKey work over SSH.
-      matchBlocks."*" = {
+      # Only forward the GPG agent to explicitly trusted hosts. Forwarding to a
+      # wildcard would expose private key operations to any remote administrator
+      # — see the Matrix.org incident for why this is dangerous:
+      # https://matrix.org/blog/2019/05/08/post-mortem-and-remediations-for-apr-11-security-incident/#ssh-agent-forwarding-should-be-disabled
+      matchBlocks."trusted-gpg-host" = {
+        host = "lambda";
         extraOptions = {
           RemoteForward = "/run/user/1000/gnupg/S.gpg-agent /run/user/1000/gnupg/S.gpg-agent.extra";
+          StreamLocalBindUnlink = "yes";
         };
       };
     };

--- a/modules/homeManagerModules/ssh.nix
+++ b/modules/homeManagerModules/ssh.nix
@@ -1,0 +1,19 @@
+{
+  flake.homeModules.ssh = {
+    config,
+    lib,
+    ...
+  }: {
+    programs.ssh = {
+      enable = true;
+
+      # Forward the local GPG agent's extra socket to remote machines so that
+      # GPG signing, encryption and authentication via YubiKey work over SSH.
+      matchBlocks."*" = {
+        extraOptions = {
+          RemoteForward = "/run/user/1000/gnupg/S.gpg-agent /run/user/1000/gnupg/S.gpg-agent.extra";
+        };
+      };
+    };
+  };
+}

--- a/modules/homeManagerModules/ssh.nix
+++ b/modules/homeManagerModules/ssh.nix
@@ -1,10 +1,13 @@
 {inputs, ...}: {
-  flake.homeModules.ssh = {config, ...}: {
+  flake.homeModules.ssh = {
     programs.ssh = {
       enable = true;
 
-      matchBlocks."gpg-forward" = {
-        host = inputs.nix-secrets.user.gpg-forward-host;
+      matchBlocks."home" = {
+        hostname = inputs.nix-secrets.user.trusted-host-addr;
+        port = 22;
+        user = "bastian";
+        identitiesOnly = true;
         extraOptions = {
           RemoteForward = "/run/user/1000/gnupg/S.gpg-agent /run/user/1000/gnupg/S.gpg-agent.extra";
           StreamLocalBindUnlink = "yes";

--- a/modules/nixosModules/features/gpg.nix
+++ b/modules/nixosModules/features/gpg.nix
@@ -4,6 +4,9 @@
       enable = true;
 
       enableSSHSupport = true;
+      # Enable the extra socket so remote machines can use the local GPG agent
+      # via SSH agent forwarding.
+      enableExtraSocket = true;
       pinentryPackage = pkgs.pinentry-curses;
       settings = {
         default-cache-ttl = 60;

--- a/modules/nixosModules/features/gpg.nix
+++ b/modules/nixosModules/features/gpg.nix
@@ -4,9 +4,6 @@
       enable = true;
 
       enableSSHSupport = true;
-      # Enable the extra socket so remote machines can use the local GPG agent
-      # via SSH agent forwarding.
-      enableExtraSocket = true;
       pinentryPackage = pkgs.pinentry-curses;
       settings = {
         default-cache-ttl = 60;

--- a/modules/nixosModules/features/impermanence.nix
+++ b/modules/nixosModules/features/impermanence.nix
@@ -4,6 +4,8 @@
     config,
     ...
   }: let
+    inherit (lib) mkIf mkAfter mkDefault mkOption mkEnableOption types;
+
     cfg = config.persistance;
   in {
     imports = [
@@ -11,68 +13,66 @@
     ];
 
     options.persistance = {
-      enable = lib.mkEnableOption "enable persistance";
+      enable = mkEnableOption "enable persistance";
 
-      nukeRoot.enable = lib.mkEnableOption "destroy /root on every boot";
+      nukeRoot.enable = mkEnableOption "destroy /root on every boot";
 
-      volumeGroup = lib.mkOption {
+      volumeGroup = mkOption {
         default = "nix";
         description = "LVM volume group name containing the btrfs root.";
-        type = lib.types.str;
+        type = types.str;
       };
 
-      directories = lib.mkOption {
+      directories = mkOption {
         default = [];
         description = "Extra system directories to persist.";
-        type = lib.types.listOf (lib.types.either lib.types.str lib.types.attrs);
+        type = types.listOf (types.either types.str types.attrs);
       };
 
-      files = lib.mkOption {
+      files = mkOption {
         default = [];
         description = "Extra system files to persist.";
-        type = lib.types.listOf (lib.types.either lib.types.str lib.types.attrs);
+        type = types.listOf (types.either types.str types.attrs);
       };
 
-      data.directories = lib.mkOption {
+      data.directories = mkOption {
         default = [];
         description = "User data directories to persist.";
-        type = lib.types.listOf (lib.types.either lib.types.str lib.types.attrs);
+        type = types.listOf (types.either types.str types.attrs);
       };
 
-      data.files = lib.mkOption {
+      data.files = mkOption {
         default = [];
         description = "User data files to persist.";
-        type = lib.types.listOf (lib.types.either lib.types.str lib.types.attrs);
+        type = types.listOf (types.either types.str types.attrs);
       };
 
-      cache.directories = lib.mkOption {
+      cache.directories = mkOption {
         default = [];
         description = "User cache directories to persist.";
-        type = lib.types.listOf (lib.types.either lib.types.str lib.types.attrs);
+        type = types.listOf (types.either types.str types.attrs);
       };
 
-      cache.files = lib.mkOption {
+      cache.files = mkOption {
         default = [];
         description = "User cache files to persist.";
-        type = lib.types.listOf (lib.types.either lib.types.str lib.types.attrs);
+        type = types.listOf (types.either types.str types.attrs);
       };
     };
 
-    config = lib.mkIf cfg.enable {
+    config = mkIf cfg.enable {
       fileSystems."/persist".neededForBoot = true;
 
       programs.fuse.userAllowOther = true;
-      boot.tmp.cleanOnBoot = lib.mkDefault true;
+      boot.tmp.cleanOnBoot = mkDefault true;
 
       environment.persistence = {
         "/persist/userdata".users."${config.preferences.user.name}" = {
-          directories = cfg.data.directories;
-          files = cfg.data.files;
+          inherit (cfg.data) directories files;
         };
 
         "/persist/usercache".users."${config.preferences.user.name}" = {
-          directories = cfg.cache.directories;
-          files = cfg.cache.files;
+          inherit (cfg.cache) directories files;
         };
 
         "/persist/system" = {
@@ -95,8 +95,8 @@
       };
 
       boot.initrd.postDeviceCommands =
-        lib.mkIf cfg.nukeRoot.enable
-        (lib.mkAfter ''
+        mkIf cfg.nukeRoot.enable
+        (mkAfter ''
           mkdir /btrfs_tmp
           mount /dev/${cfg.volumeGroup}/root /btrfs_tmp
           if [[ -e /btrfs_tmp/root ]]; then

--- a/modules/nixosModules/features/impermanence.nix
+++ b/modules/nixosModules/features/impermanence.nix
@@ -4,8 +4,29 @@
       inputs.impermanence.nixosModules.impermanence
     ];
 
-    # Persist essential system and user state across reboots so that fresh
-    # installs behave identically to long-running systems.
+    # On a btrfs root, the recommended approach is to create a blank snapshot
+    # of the root subvolume at install time:
+    #
+    #   btrfs subvolume snapshot -r /mnt/root /mnt/root-blank
+    #
+    # Then on every boot, roll back the root subvolume to the blank snapshot
+    # so that only explicitly persisted state survives reboots.
+    boot.initrd.postResumeCommands = lib.mkAfter ''
+      mkdir -p /mnt
+      mount -o subvol=/ /dev/mapper/luks_lvm-root /mnt
+
+      if [ -e /mnt/root-blank ]; then
+        btrfs subvolume delete /mnt/root/old_root 2>/dev/null || true
+        mv /mnt/root /mnt/root/old_root 2>/dev/null || true
+        btrfs subvolume snapshot /mnt/root-blank /mnt/root
+      fi
+
+      umount /mnt
+    '';
+
+    # Persist essential system state. Paths listed here are bind-mounted from
+    # /nix/persist into the ephemeral root, so they survive the snapshot
+    # rollback above.
     environment.persistence."/nix/persist" = {
       hideMounts = true;
 
@@ -21,43 +42,54 @@
       files = [
         "/etc/machine-id"
       ];
+    };
 
-      users.bastian = {
-        directories = [
-          "Documents"
-          "Downloads"
-          "Music"
-          "Pictures"
-          "Projects"
-          "Videos"
-          ".local/share/direnv"
-          ".local/state/nvim"
-          ".local/share/nvim"
-          ".local/state/zsh"
+    # Home Manager impermanence is configured separately in the home module
+    # below so that it tracks the user's own state directories.
+  };
 
-          # Firefox profile state (extensions, uBlock settings, etc.)
-          ".mozilla"
+  flake.homeModules.impermanence = {
+    imports = [
+      inputs.impermanence.homeManagerModules.impermanence
+    ];
 
-          # GPG and SSH agent state.
-          ".gnupg"
+    home.persistence."/nix/persist/home/bastian" = {
+      allowOther = true;
 
-          # Password store.
-          ".local/share/password-store"
+      directories = [
+        "Documents"
+        "Downloads"
+        "Music"
+        "Pictures"
+        "Projects"
+        "Videos"
+        ".local/share/direnv"
+        ".local/state/nvim"
+        ".local/share/nvim"
+        ".local/state/zsh"
 
-          # Discord state.
-          {
-            directory = ".config/discord";
-            mode = "0700";
-          }
+        # Firefox profile state (extensions, uBlock Origin settings, etc.)
+        ".mozilla"
 
-          # Spotify state.
-          ".config/spotify"
-        ];
+        # GPG and SSH agent state.
+        ".gnupg"
 
-        files = [
-          ".config/monitors.xml"
-        ];
-      };
+        # Password store.
+        ".local/share/password-store"
+
+        # Discord state.
+        {
+          directory = ".config/discord";
+          mode = "0700";
+        }
+
+        # Spotify state.
+        ".config/spotify"
+      ];
+
+      files = [
+        ".config/monitors.xml"
+      ];
     };
   };
 }

--- a/modules/nixosModules/features/impermanence.nix
+++ b/modules/nixosModules/features/impermanence.nix
@@ -1,95 +1,125 @@
 {inputs, ...}: {
-  flake.nixosModules.impermanence = {lib, ...}: {
+  flake.nixosModules.impermanence = {
+    lib,
+    config,
+    ...
+  }: let
+    cfg = config.persistance;
+  in {
     imports = [
       inputs.impermanence.nixosModules.impermanence
     ];
 
-    # On a btrfs root, the recommended approach is to create a blank snapshot
-    # of the root subvolume at install time:
-    #
-    #   btrfs subvolume snapshot -r /mnt/root /mnt/root-blank
-    #
-    # Then on every boot, roll back the root subvolume to the blank snapshot
-    # so that only explicitly persisted state survives reboots.
-    boot.initrd.postResumeCommands = lib.mkAfter ''
-      mkdir -p /mnt
-      mount -o subvol=/ /dev/mapper/luks_lvm-root /mnt
+    options.persistance = {
+      enable = lib.mkEnableOption "enable persistance";
 
-      if [ -e /mnt/root-blank ]; then
-        btrfs subvolume delete /mnt/root/old_root 2>/dev/null || true
-        mv /mnt/root /mnt/root/old_root 2>/dev/null || true
-        btrfs subvolume snapshot /mnt/root-blank /mnt/root
-      fi
+      nukeRoot.enable = lib.mkEnableOption "destroy /root on every boot";
 
-      umount /mnt
-    '';
+      volumeGroup = lib.mkOption {
+        default = "nix";
+        description = "LVM volume group name containing the btrfs root.";
+        type = lib.types.str;
+      };
 
-    # Persist essential system state. Paths listed here are bind-mounted from
-    # /nix/persist into the ephemeral root, so they survive the snapshot
-    # rollback above.
-    environment.persistence."/nix/persist" = {
-      hideMounts = true;
+      directories = lib.mkOption {
+        default = [];
+        description = "Extra system directories to persist.";
+        type = lib.types.listOf (lib.types.either lib.types.str lib.types.attrs);
+      };
 
-      directories = [
-        "/var/log"
-        "/var/lib/bluetooth"
-        "/var/lib/nixos"
-        "/var/lib/systemd/coredump"
-        "/var/lib/tailscale"
-        "/etc/NetworkManager/system-connections"
-      ];
+      files = lib.mkOption {
+        default = [];
+        description = "Extra system files to persist.";
+        type = lib.types.listOf (lib.types.either lib.types.str lib.types.attrs);
+      };
 
-      files = [
-        "/etc/machine-id"
-      ];
+      data.directories = lib.mkOption {
+        default = [];
+        description = "User data directories to persist.";
+        type = lib.types.listOf (lib.types.either lib.types.str lib.types.attrs);
+      };
+
+      data.files = lib.mkOption {
+        default = [];
+        description = "User data files to persist.";
+        type = lib.types.listOf (lib.types.either lib.types.str lib.types.attrs);
+      };
+
+      cache.directories = lib.mkOption {
+        default = [];
+        description = "User cache directories to persist.";
+        type = lib.types.listOf (lib.types.either lib.types.str lib.types.attrs);
+      };
+
+      cache.files = lib.mkOption {
+        default = [];
+        description = "User cache files to persist.";
+        type = lib.types.listOf (lib.types.either lib.types.str lib.types.attrs);
+      };
     };
 
-    # Home Manager impermanence is configured separately in the home module
-    # below so that it tracks the user's own state directories.
-  };
+    config = lib.mkIf cfg.enable {
+      fileSystems."/persist".neededForBoot = true;
 
-  flake.homeModules.impermanence = {
-    imports = [
-      inputs.impermanence.homeManagerModules.impermanence
-    ];
+      programs.fuse.userAllowOther = true;
+      boot.tmp.cleanOnBoot = lib.mkDefault true;
 
-    home.persistence."/nix/persist/home/bastian" = {
-      allowOther = true;
+      environment.persistence = {
+        "/persist/userdata".users."${config.preferences.user.name}" = {
+          directories = cfg.data.directories;
+          files = cfg.data.files;
+        };
 
-      directories = [
-        "Documents"
-        "Downloads"
-        "Music"
-        "Pictures"
-        "Projects"
-        "Videos"
-        ".local/share/direnv"
-        ".local/state/nvim"
-        ".local/share/nvim"
-        ".local/state/zsh"
+        "/persist/usercache".users."${config.preferences.user.name}" = {
+          directories = cfg.cache.directories;
+          files = cfg.cache.files;
+        };
 
-        # Firefox profile state (extensions, uBlock Origin settings, etc.)
-        ".mozilla"
+        "/persist/system" = {
+          hideMounts = true;
+          directories =
+            [
+              "/var/log"
+              "/var/lib/bluetooth"
+              "/var/lib/nixos"
+              "/var/lib/systemd/coredump"
+              "/etc/NetworkManager/system-connections"
+            ]
+            ++ cfg.directories;
+          files =
+            [
+              "/etc/machine-id"
+            ]
+            ++ cfg.files;
+        };
+      };
 
-        # GPG and SSH agent state.
-        ".gnupg"
+      boot.initrd.postDeviceCommands =
+        lib.mkIf cfg.nukeRoot.enable
+        (lib.mkAfter ''
+          mkdir /btrfs_tmp
+          mount /dev/${cfg.volumeGroup}/root /btrfs_tmp
+          if [[ -e /btrfs_tmp/root ]]; then
+              mkdir -p /btrfs_tmp/old_roots
+              timestamp=$(date --date="@$(stat -c %Y /btrfs_tmp/root)" "+%Y-%m-%-d_%H:%M:%S")
+              mv /btrfs_tmp/root "/btrfs_tmp/old_roots/$timestamp"
+          fi
 
-        # Password store.
-        ".local/share/password-store"
+          delete_subvolume_recursively() {
+              IFS=$'\n'
+              for i in $(btrfs subvolume list -o "$1" | cut -f 9- -d ' '); do
+                  delete_subvolume_recursively "/btrfs_tmp/$i"
+              done
+              btrfs subvolume delete "$1"
+          }
 
-        # Discord state.
-        {
-          directory = ".config/discord";
-          mode = "0700";
-        }
+          for i in $(find /btrfs_tmp/old_roots/ -maxdepth 1 -mtime +30); do
+              delete_subvolume_recursively "$i"
+          done
 
-        # Spotify state.
-        ".config/spotify"
-      ];
-
-      files = [
-        ".config/monitors.xml"
-      ];
+          btrfs subvolume create /btrfs_tmp/root
+          umount /btrfs_tmp
+        '');
     };
   };
 }

--- a/modules/nixosModules/features/impermanence.nix
+++ b/modules/nixosModules/features/impermanence.nix
@@ -1,0 +1,63 @@
+{inputs, ...}: {
+  flake.nixosModules.impermanence = {lib, ...}: {
+    imports = [
+      inputs.impermanence.nixosModules.impermanence
+    ];
+
+    # Persist essential system and user state across reboots so that fresh
+    # installs behave identically to long-running systems.
+    environment.persistence."/nix/persist" = {
+      hideMounts = true;
+
+      directories = [
+        "/var/log"
+        "/var/lib/bluetooth"
+        "/var/lib/nixos"
+        "/var/lib/systemd/coredump"
+        "/var/lib/tailscale"
+        "/etc/NetworkManager/system-connections"
+      ];
+
+      files = [
+        "/etc/machine-id"
+      ];
+
+      users.bastian = {
+        directories = [
+          "Documents"
+          "Downloads"
+          "Music"
+          "Pictures"
+          "Projects"
+          "Videos"
+          ".local/share/direnv"
+          ".local/state/nvim"
+          ".local/share/nvim"
+          ".local/state/zsh"
+
+          # Firefox profile state (extensions, uBlock settings, etc.)
+          ".mozilla"
+
+          # GPG and SSH agent state.
+          ".gnupg"
+
+          # Password store.
+          ".local/share/password-store"
+
+          # Discord state.
+          {
+            directory = ".config/discord";
+            mode = "0700";
+          }
+
+          # Spotify state.
+          ".config/spotify"
+        ];
+
+        files = [
+          ".config/monitors.xml"
+        ];
+      };
+    };
+  };
+}

--- a/modules/nixosModules/features/kanata.nix
+++ b/modules/nixosModules/features/kanata.nix
@@ -1,0 +1,48 @@
+{
+  flake.nixosModules.kanata = {
+    lib,
+    pkgs,
+    ...
+  }: {
+    services.kanata = {
+      enable = true;
+
+      keyboards.default = {
+        extraDefCfg = "process-unmapped-keys yes";
+        config = ''
+          ;; Colemak-DH with home-row mods.
+          ;; Tap = letter, hold = modifier.
+          (defsrc
+            grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc
+            tab  q    w    e    r    t    y    u    i    o    p    [    ]    \
+            caps a    s    d    f    g    h    j    k    l    ;    '    ret
+            lsft z    x    c    v    b    n    m    ,    .    /    rsft
+            lctl lmet lalt           spc            ralt rmet rctl
+          )
+
+          (deflayer colemak-dh
+            grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc
+            tab  q    w    f    p    b    j    l    u    y    ;    [    ]    \
+            esc  @a_m @r_a @s_c @t_s g    m    @n_s @e_c @i_a @o_m '    ret
+            lsft x    c    d    v    z    k    h    ,    .    /    rsft
+            lctl lmet lalt           spc            ralt rmet rctl
+          )
+
+          (defalias
+            ;; Left-hand home-row mods.
+            a_m (tap-hold 200 150 a lmet)
+            r_a (tap-hold 200 150 r lalt)
+            s_c (tap-hold 200 150 s lctl)
+            t_s (tap-hold 200 150 t lsft)
+
+            ;; Right-hand home-row mods (mirrored).
+            n_s (tap-hold 200 150 n rsft)
+            e_c (tap-hold 200 150 e rctl)
+            i_a (tap-hold 200 150 i lalt)
+            o_m (tap-hold 200 150 o rmet)
+          )
+        '';
+      };
+    };
+  };
+}

--- a/modules/nixosModules/features/kanata.nix
+++ b/modules/nixosModules/features/kanata.nix
@@ -1,17 +1,24 @@
 {
-  flake.nixosModules.kanata = {
-    lib,
-    pkgs,
-    ...
-  }: {
+  flake.nixosModules.kanata = {lib, ...}: {
     services.kanata = {
       enable = true;
 
       keyboards.default = {
         extraDefCfg = "process-unmapped-keys yes";
         config = ''
-          ;; Colemak-DH with home-row mods.
-          ;; Tap = letter, hold = modifier.
+          ;; Danish Colemak-DH layout with bilateral home-row mods.
+          ;; Mirrors the Glove80 Glorious Engrammer configuration so that
+          ;; Delta's built-in keyboard behaves identically to the external
+          ;; split keyboard.
+          ;;
+          ;; The defsrc assumes a standard ANSI physical layout. Because XKB
+          ;; (set to "dk" in niri) applies *after* kanata's output, the
+          ;; Danish-specific keys (æ/ø/å at ;/' /[ positions) remain intact.
+          ;;
+          ;; Home-row mods use tap-preferred with 200ms tapping term to
+          ;; match the Glove80 difficulty-level-4 timing. Bilateral
+          ;; enforcement is not available in kanata, so care was taken to
+          ;; mirror the Glove80's GACS (GUI-Alt-Ctrl-Shift) order.
           (defsrc
             grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc
             tab  q    w    e    r    t    y    u    i    o    p    [    ]    \
@@ -23,23 +30,23 @@
           (deflayer colemak-dh
             grv  1    2    3    4    5    6    7    8    9    0    -    =    bspc
             tab  q    w    f    p    b    j    l    u    y    ;    [    ]    \
-            esc  @a_m @r_a @s_c @t_s g    m    @n_s @e_c @i_a @o_m '    ret
+            esc  @a_g @r_a @s_c @t_s g    m    @n_s @e_c @i_a @o_g '    ret
             lsft x    c    d    v    z    k    h    ,    .    /    rsft
             lctl lmet lalt           spc            ralt rmet rctl
           )
 
           (defalias
-            ;; Left-hand home-row mods.
-            a_m (tap-hold 200 150 a lmet)
-            r_a (tap-hold 200 150 r lalt)
-            s_c (tap-hold 200 150 s lctl)
-            t_s (tap-hold 200 150 t lsft)
+            ;; Left-hand home-row mods (GACS order, matching Glove80).
+            a_g (tap-hold 200 150 a lmet)   ;; tap a, hold GUI
+            r_a (tap-hold 200 150 r lalt)   ;; tap r, hold Alt
+            s_c (tap-hold 200 150 s lctl)   ;; tap s, hold Ctrl
+            t_s (tap-hold 200 150 t lsft)   ;; tap t, hold Shift
 
-            ;; Right-hand home-row mods (mirrored).
-            n_s (tap-hold 200 150 n rsft)
-            e_c (tap-hold 200 150 e rctl)
-            i_a (tap-hold 200 150 i lalt)
-            o_m (tap-hold 200 150 o rmet)
+            ;; Right-hand home-row mods (mirrored GACS).
+            n_s (tap-hold 200 150 n rsft)   ;; tap n, hold Shift
+            e_c (tap-hold 200 150 e rctl)   ;; tap e, hold Ctrl
+            i_a (tap-hold 200 150 i lalt)   ;; tap i, hold Alt
+            o_g (tap-hold 200 150 o rmet)   ;; tap o, hold GUI
           )
         '';
       };

--- a/modules/nixosModules/features/kanata.nix
+++ b/modules/nixosModules/features/kanata.nix
@@ -1,5 +1,5 @@
 {
-  flake.nixosModules.kanata = {lib, ...}: {
+  flake.nixosModules.kanata = {
     services.kanata = {
       enable = true;
 

--- a/modules/nixosModules/features/luks-fido2.nix
+++ b/modules/nixosModules/features/luks-fido2.nix
@@ -1,0 +1,19 @@
+{
+  flake.nixosModules.luksFido2 = {
+    # The default script-based initrd does not include the systemd-cryptenroll
+    # FIDO2 token handling required by `fido2-device=auto` in crypttabExtraOpts.
+    # Switching to the systemd-based initrd pulls in systemd-cryptsetup which
+    # knows how to talk to FIDO2 tokens (via libfido2) at boot.
+    boot.initrd = {
+      systemd.enable = true;
+
+      # dm-crypt must be loaded in the initrd so the LUKS volume can be
+      # opened before the root filesystem is mounted.
+      kernelModules = ["dm-crypt"];
+
+      # Ensure USB storage drivers are available in case the FIDO2 token
+      # is on a USB bus that the default module set does not cover.
+      availableKernelModules = ["usb_storage" "uas"];
+    };
+  };
+}

--- a/modules/nixosModules/features/security.nix
+++ b/modules/nixosModules/features/security.nix
@@ -28,28 +28,56 @@
         "net.ipv4.tcp_congestion_control" = "bbr";
         "net.core.default_qdisc" = "cake";
 
-        ## Kernel pointer and dmesg restrictions.
+        # Hide kernel symbol addresses in /proc/kallsyms and other interfaces.
+        # Without this, a local attacker (or an info-leak bug) can trivially
+        # defeat KASLR by reading raw pointers, making ROP chains easier to
+        # construct. Value 2 hides them from everyone, including root processes
+        # that lack CAP_SYSLOG.
         "kernel.kptr_restrict" = 2;
+
+        # Restrict dmesg to root (CAP_SYSLOG). The kernel ring buffer often
+        # leaks KASLR base offsets, driver addresses, and hardware details that
+        # aid local privilege-escalation exploits. Users who need dmesg can use
+        # `journalctl -k` with appropriate group membership instead.
         "kernel.dmesg_restrict" = 1;
 
-        ## Disable unprivileged user namespaces (reduces attack surface).
+        # Limit unprivileged user namespaces. User namespaces let unprivileged
+        # code reach kernel syscall surfaces (e.g. mount, network) that are
+        # rarely tested against hostile callers — they have been the entry point
+        # for numerous container-escape and LPE CVEs (e.g. CVE-2022-0185).
         "kernel.unprivileged_userns_clone" = 0;
 
-        ## Restrict ptrace to direct child processes only.
+        # Restrict ptrace to a process's direct descendants only. Without this,
+        # any process running as the same user can attach to any other, making
+        # it trivial for malware or a compromised browser renderer to read
+        # secrets from ssh-agent, GPG agent, or password managers.
         "kernel.yama.ptrace_scope" = 1;
-
-        ## Disable core dumps.
-        "fs.suid_dumpable" = 0;
       };
 
       kernelModules = ["tcp_bbr"];
 
-      # Kernel parameters for additional hardening.
       kernelParams = [
+        # Prevent adjacent slab caches from being merged. Merging saves memory
+        # but lets a use-after-free in one cache corrupt objects of a different
+        # type, which is the foundation of most modern kernel heap exploits
+        # (cross-cache attacks). The memory overhead is minimal on a desktop.
         "slab_nomerge"
+
+        # Zero-fill pages on allocation and free. This stops stale kernel heap
+        # data (crypto keys, network buffers, credentials) from leaking to
+        # userspace or to subsequently allocated objects. Measured overhead is
+        # ~1% on typical desktop workloads.
         "init_on_alloc=1"
         "init_on_free=1"
+
+        # Randomise the order in which the page allocator hands out pages. This
+        # makes page-level heap-spraying attacks significantly harder by
+        # breaking the predictable allocation patterns they rely on.
         "page_alloc.shuffle=1"
+
+        # Randomise the kernel stack offset on every syscall entry, defeating
+        # stack-layout-dependent exploits that rely on deterministic offsets
+        # between stack frames. Negligible performance cost.
         "randomize_kstack_offset=on"
       ];
     };
@@ -65,7 +93,6 @@
       };
 
       protectKernelImage = true;
-      lockKernelModules = false;
       forcePageTableIsolation = true;
       polkit.enable = true;
       rtkit.enable = true;
@@ -77,17 +104,9 @@
       virtualisation.flushL1DataCache = "always";
     };
 
-    # Enable the firewall with a deny-all-inbound default.
-    networking.firewall = {
-      enable = true;
-      allowPing = false;
-      logReversePathDrops = true;
-    };
-
-    # Harden systemd services.
-    systemd.coredump.extraConfig = ''
-      Storage=none
-      ProcessSizeMax=0
-    '';
+    # Log packets that fail reverse-path filtering. This surfaces spoofed
+    # traffic (e.g. from a compromised LAN device) in the system journal so
+    # it can be investigated, complementing the rp_filter sysctl above.
+    networking.firewall.logReversePathDrops = true;
   };
 }

--- a/modules/nixosModules/features/security.nix
+++ b/modules/nixosModules/features/security.nix
@@ -27,9 +27,31 @@
         "net.ipv4.tcp_fastopen" = 3;
         "net.ipv4.tcp_congestion_control" = "bbr";
         "net.core.default_qdisc" = "cake";
+
+        ## Kernel pointer and dmesg restrictions.
+        "kernel.kptr_restrict" = 2;
+        "kernel.dmesg_restrict" = 1;
+
+        ## Disable unprivileged user namespaces (reduces attack surface).
+        "kernel.unprivileged_userns_clone" = 0;
+
+        ## Restrict ptrace to direct child processes only.
+        "kernel.yama.ptrace_scope" = 1;
+
+        ## Disable core dumps.
+        "fs.suid_dumpable" = 0;
       };
 
       kernelModules = ["tcp_bbr"];
+
+      # Kernel parameters for additional hardening.
+      kernelParams = [
+        "slab_nomerge"
+        "init_on_alloc=1"
+        "init_on_free=1"
+        "page_alloc.shuffle=1"
+        "randomize_kstack_offset=on"
+      ];
     };
 
     # Security hardening
@@ -43,6 +65,7 @@
       };
 
       protectKernelImage = true;
+      lockKernelModules = false;
       forcePageTableIsolation = true;
       polkit.enable = true;
       rtkit.enable = true;
@@ -53,5 +76,18 @@
       # Always flush L1 cache before entering a guest.
       virtualisation.flushL1DataCache = "always";
     };
+
+    # Enable the firewall with a deny-all-inbound default.
+    networking.firewall = {
+      enable = true;
+      allowPing = false;
+      logReversePathDrops = true;
+    };
+
+    # Harden systemd services.
+    systemd.coredump.extraConfig = ''
+      Storage=none
+      ProcessSizeMax=0
+    '';
   };
 }

--- a/modules/nixosModules/features/security.nix
+++ b/modules/nixosModules/features/security.nix
@@ -1,9 +1,7 @@
 {
   flake.nixosModules.security = {pkgs, ...}: {
-    # Kernel hardening.
     boot = {
       kernel.sysctl = {
-        # Disable Magic SysRq key.
         "kernel.sysrq" = 0;
 
         ## TCP Hardening
@@ -28,61 +26,27 @@
         "net.ipv4.tcp_congestion_control" = "bbr";
         "net.core.default_qdisc" = "cake";
 
-        # Hide kernel symbol addresses in /proc/kallsyms and other interfaces.
-        # Without this, a local attacker (or an info-leak bug) can trivially
-        # defeat KASLR by reading raw pointers, making ROP chains easier to
-        # construct. Value 2 hides them from everyone, including root processes
-        # that lack CAP_SYSLOG.
+        # Defeats KASLR info-leaks via /proc/kallsyms.
         "kernel.kptr_restrict" = 2;
-
-        # Restrict dmesg to root (CAP_SYSLOG). The kernel ring buffer often
-        # leaks KASLR base offsets, driver addresses, and hardware details that
-        # aid local privilege-escalation exploits. Users who need dmesg can use
-        # `journalctl -k` with appropriate group membership instead.
+        # Prevents LPE exploits from harvesting driver addresses in dmesg.
         "kernel.dmesg_restrict" = 1;
-
-        # Limit unprivileged user namespaces. User namespaces let unprivileged
-        # code reach kernel syscall surfaces (e.g. mount, network) that are
-        # rarely tested against hostile callers — they have been the entry point
-        # for numerous container-escape and LPE CVEs (e.g. CVE-2022-0185).
+        # User namespaces reach rarely-tested kernel surfaces (CVE-2022-0185 etc.).
         "kernel.unprivileged_userns_clone" = 0;
-
-        # Restrict ptrace to a process's direct descendants only. Without this,
-        # any process running as the same user can attach to any other, making
-        # it trivial for malware or a compromised browser renderer to read
-        # secrets from ssh-agent, GPG agent, or password managers.
+        # Stops same-user processes from ptracing ssh-agent/gpg-agent.
         "kernel.yama.ptrace_scope" = 1;
       };
 
       kernelModules = ["tcp_bbr"];
 
       kernelParams = [
-        # Prevent adjacent slab caches from being merged. Merging saves memory
-        # but lets a use-after-free in one cache corrupt objects of a different
-        # type, which is the foundation of most modern kernel heap exploits
-        # (cross-cache attacks). The memory overhead is minimal on a desktop.
         "slab_nomerge"
-
-        # Zero-fill pages on allocation and free. This stops stale kernel heap
-        # data (crypto keys, network buffers, credentials) from leaking to
-        # userspace or to subsequently allocated objects. Measured overhead is
-        # ~1% on typical desktop workloads.
         "init_on_alloc=1"
         "init_on_free=1"
-
-        # Randomise the order in which the page allocator hands out pages. This
-        # makes page-level heap-spraying attacks significantly harder by
-        # breaking the predictable allocation patterns they rely on.
         "page_alloc.shuffle=1"
-
-        # Randomise the kernel stack offset on every syscall entry, defeating
-        # stack-layout-dependent exploits that rely on deterministic offsets
-        # between stack frames. Negligible performance cost.
         "randomize_kstack_offset=on"
       ];
     };
 
-    # Security hardening
     security = {
       apparmor = {
         enable = true;
@@ -100,13 +64,9 @@
       sudo.enable = false;
       sudo-rs.enable = true;
 
-      # Always flush L1 cache before entering a guest.
       virtualisation.flushL1DataCache = "always";
     };
 
-    # Log packets that fail reverse-path filtering. This surfaces spoofed
-    # traffic (e.g. from a compromised LAN device) in the system journal so
-    # it can be investigated, complementing the rp_filter sysctl above.
     networking.firewall.logReversePathDrops = true;
   };
 }

--- a/modules/nixosModules/features/ssh.nix
+++ b/modules/nixosModules/features/ssh.nix
@@ -25,6 +25,7 @@
           PermitUserEnvironment = "no";
           AllowAgentForwarding = "no";
           AllowTcpForwarding = "no";
+          StreamLocalBindUnlink = "yes";
           PermitTunnel = "no";
           UsePAM = false;
           KbdInteractiveAuthentication = false;

--- a/modules/nixosModules/hosts/delta/configuration.nix
+++ b/modules/nixosModules/hosts/delta/configuration.nix
@@ -41,6 +41,7 @@
       self.nixosModules.gpg
       self.nixosModules.yubiKey
       self.nixosModules.tailscale
+      self.nixosModules.luksFido2
 
       # Keyboard
       self.nixosModules.kanata

--- a/modules/nixosModules/hosts/delta/configuration.nix
+++ b/modules/nixosModules/hosts/delta/configuration.nix
@@ -42,6 +42,9 @@
       self.nixosModules.yubiKey
       self.nixosModules.tailscale
 
+      # Keyboard
+      self.nixosModules.kanata
+
       # Features
       self.nixosModules.bluetooth
       self.nixosModules.btrfs
@@ -82,6 +85,7 @@
       tmux
       tmuxSessionizer
       gpg
+      ssh
       ohMyPosh
       bat
       btop

--- a/modules/nixosModules/hosts/delta/hardware-configuration.nix
+++ b/modules/nixosModules/hosts/delta/hardware-configuration.nix
@@ -11,11 +11,8 @@
 
     boot = {
       initrd = {
-        availableKernelModules = ["xhci_pci" "thunderbolt" "vmd" "nvme" "usbhid" "usb_storage" "uas"];
-        kernelModules = ["dm-snapshot" "dm-crypt"];
-
-        # systemd-based initrd is required for FIDO2-based LUKS unlocking.
-        systemd.enable = true;
+        availableKernelModules = ["xhci_pci" "thunderbolt" "vmd" "nvme" "usbhid"];
+        kernelModules = ["dm-snapshot"];
       };
 
       kernelModules = ["kvm-intel"];

--- a/modules/nixosModules/hosts/delta/hardware-configuration.nix
+++ b/modules/nixosModules/hosts/delta/hardware-configuration.nix
@@ -11,8 +11,11 @@
 
     boot = {
       initrd = {
-        availableKernelModules = ["xhci_pci" "thunderbolt" "vmd" "nvme" "usbhid"];
-        kernelModules = ["dm-snapshot"];
+        availableKernelModules = ["xhci_pci" "thunderbolt" "vmd" "nvme" "usbhid" "usb_storage" "uas"];
+        kernelModules = ["dm-snapshot" "dm-crypt"];
+
+        # systemd-based initrd is required for FIDO2-based LUKS unlocking.
+        systemd.enable = true;
       };
 
       kernelModules = ["kvm-intel"];

--- a/modules/nixosModules/hosts/lambda/configuration.nix
+++ b/modules/nixosModules/hosts/lambda/configuration.nix
@@ -42,6 +42,7 @@
       self.nixosModules.ssh
       self.nixosModules.tailscale
       self.nixosModules.yubiKey
+      self.nixosModules.luksFido2
 
       # Features
       self.nixosModules.bluetooth

--- a/modules/nixosModules/hosts/lambda/configuration.nix
+++ b/modules/nixosModules/hosts/lambda/configuration.nix
@@ -121,6 +121,7 @@
       tmux
       tmuxSessionizer
       gpg
+      ssh
       ohMyPosh
       bat
       btop

--- a/modules/templates/_c/.envrc
+++ b/modules/templates/_c/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/modules/templates/_c/.gitignore
+++ b/modules/templates/_c/.gitignore
@@ -1,0 +1,4 @@
+# Ignore results from `nix build`.
+result*
+
+build/

--- a/modules/templates/_c/CMakeLists.txt
+++ b/modules/templates/_c/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(sample-project VERSION 0.1.0 LANGUAGES C)
+
+set(CMAKE_C_STANDARD 23)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+add_executable(sample-project src/main.c)

--- a/modules/templates/_c/LICENSE
+++ b/modules/templates/_c/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 Bastian Asmussen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/modules/templates/_c/README.md
+++ b/modules/templates/_c/README.md
@@ -1,0 +1,22 @@
+# C Project Template
+
+This project is built using [Nix](https://nixos.org).
+
+## Getting Started
+
+- Enter the development shell with `nix develop`.
+- Run `cmake -B build && cmake --build build` to compile.
+
+## Usage
+
+### Building
+
+```sh
+nix build
+```
+
+### Running
+
+```sh
+nix run
+```

--- a/modules/templates/_c/flake.nix
+++ b/modules/templates/_c/flake.nix
@@ -1,0 +1,45 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs @ {flake-parts, ...}:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux"];
+      perSystem = {pkgs, ...}: let
+        commonArgs = {
+          buildInputs = [];
+          nativeBuildInputs = with pkgs; [
+            cmake
+            pkg-config
+          ];
+        };
+      in {
+        packages.default = pkgs.stdenv.mkDerivation (commonArgs
+          // {
+            pname = "sample-project";
+            version = "0.1.0";
+
+            src = ./.;
+
+            installPhase = ''
+              mkdir -p $out/bin
+              cp sample-project $out/bin/
+            '';
+          });
+
+        devShells.default = pkgs.mkShell (commonArgs
+          // {
+            buildInputs = with pkgs; [
+              gcc
+              gnumake
+              cmake
+              gdb
+              valgrind
+              clang-tools
+            ];
+          });
+      };
+    };
+}

--- a/modules/templates/_c/src/main.c
+++ b/modules/templates/_c/src/main.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main(void) {
+    printf("Hello, World!\n");
+
+    return 0;
+}

--- a/modules/templates/_csharp/.envrc
+++ b/modules/templates/_csharp/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/modules/templates/_csharp/.gitignore
+++ b/modules/templates/_csharp/.gitignore
@@ -1,0 +1,5 @@
+# Ignore results from `nix build`.
+result*
+
+bin/
+obj/

--- a/modules/templates/_csharp/LICENSE
+++ b/modules/templates/_csharp/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 Bastian Asmussen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/modules/templates/_csharp/README.md
+++ b/modules/templates/_csharp/README.md
@@ -1,0 +1,22 @@
+# C# Project Template
+
+This project is built using [Nix](https://nixos.org).
+
+## Getting Started
+
+- Enter the development shell with `nix develop`.
+- Run `dotnet new console -n MyProject` to scaffold a new project.
+
+## Usage
+
+### Building
+
+```sh
+dotnet build
+```
+
+### Running
+
+```sh
+dotnet run
+```

--- a/modules/templates/_csharp/README.md
+++ b/modules/templates/_csharp/README.md
@@ -5,18 +5,17 @@ This project is built using [Nix](https://nixos.org).
 ## Getting Started
 
 - Enter the development shell with `nix develop`.
-- Run `dotnet new console -n MyProject` to scaffold a new project.
 
 ## Usage
 
 ### Building
 
 ```sh
-dotnet build
+nix build
 ```
 
 ### Running
 
 ```sh
-dotnet run
+nix run
 ```

--- a/modules/templates/_csharp/SampleProject/Program.cs
+++ b/modules/templates/_csharp/SampleProject/Program.cs
@@ -1,0 +1,1 @@
+Console.WriteLine("Hello, World!");

--- a/modules/templates/_csharp/SampleProject/SampleProject.csproj
+++ b/modules/templates/_csharp/SampleProject/SampleProject.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <RootNamespace>SampleProject</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/modules/templates/_csharp/flake.nix
+++ b/modules/templates/_csharp/flake.nix
@@ -9,14 +9,14 @@
       systems = ["x86_64-linux"];
       perSystem = {pkgs, ...}: let
         dotnet = pkgs.dotnetCorePackages.sdk_9_0;
+        runtime = pkgs.dotnetCorePackages.runtime_9_0;
       in {
         packages.default = pkgs.stdenv.mkDerivation {
           pname = "sample-project";
           version = "0.1.0";
 
           src = ./.;
-
-          nativeBuildInputs = [dotnet];
+          nativeBuildInputs = [dotnet pkgs.makeWrapper];
 
           buildPhase = ''
             export HOME=$TMPDIR
@@ -28,8 +28,10 @@
           '';
 
           installPhase = ''
-            mkdir -p $out/bin
-            cp -r out/* $out/bin/
+            mkdir -p $out/lib/sample-project $out/bin
+            cp -r out/* $out/lib/sample-project/
+            makeWrapper ${runtime}/bin/dotnet $out/bin/sample-project \
+              --add-flags "$out/lib/sample-project/SampleProject.dll"
           '';
         };
 

--- a/modules/templates/_csharp/flake.nix
+++ b/modules/templates/_csharp/flake.nix
@@ -1,0 +1,24 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs @ {flake-parts, ...}:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux"];
+      perSystem = {pkgs, ...}: let
+        dotnet = pkgs.dotnetCorePackages.sdk_9_0;
+      in {
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            dotnet
+            pkgs.omnisharp-roslyn
+          ];
+
+          env.DOTNET_ROOT = "${dotnet}";
+          env.DOTNET_CLI_TELEMETRY_OPTOUT = "1";
+        };
+      };
+    };
+}

--- a/modules/templates/_csharp/flake.nix
+++ b/modules/templates/_csharp/flake.nix
@@ -10,6 +10,17 @@
       perSystem = {pkgs, ...}: let
         dotnet = pkgs.dotnetCorePackages.sdk_9_0;
       in {
+        packages.default = pkgs.buildDotnetModule {
+          pname = "sample-project";
+          version = "0.1.0";
+
+          src = ./.;
+          projectFile = "SampleProject/SampleProject.csproj";
+          nugetDeps = ./deps.json;
+          dotnet-sdk = dotnet;
+          dotnet-runtime = pkgs.dotnetCorePackages.runtime_9_0;
+        };
+
         devShells.default = pkgs.mkShell {
           buildInputs = [
             dotnet

--- a/modules/templates/_csharp/flake.nix
+++ b/modules/templates/_csharp/flake.nix
@@ -10,15 +10,27 @@
       perSystem = {pkgs, ...}: let
         dotnet = pkgs.dotnetCorePackages.sdk_9_0;
       in {
-        packages.default = pkgs.buildDotnetModule {
+        packages.default = pkgs.stdenv.mkDerivation {
           pname = "sample-project";
           version = "0.1.0";
 
           src = ./.;
-          projectFile = "SampleProject/SampleProject.csproj";
-          nugetDeps = ./deps.json;
-          dotnet-sdk = dotnet;
-          dotnet-runtime = pkgs.dotnetCorePackages.runtime_9_0;
+
+          nativeBuildInputs = [dotnet];
+
+          buildPhase = ''
+            export HOME=$TMPDIR
+            export DOTNET_CLI_TELEMETRY_OPTOUT=1
+            dotnet publish SampleProject/SampleProject.csproj \
+              -c Release \
+              -o out \
+              --self-contained false
+          '';
+
+          installPhase = ''
+            mkdir -p $out/bin
+            cp -r out/* $out/bin/
+          '';
         };
 
         devShells.default = pkgs.mkShell {

--- a/modules/templates/_haskell/.envrc
+++ b/modules/templates/_haskell/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/modules/templates/_haskell/.gitignore
+++ b/modules/templates/_haskell/.gitignore
@@ -1,0 +1,4 @@
+# Ignore results from `nix build`.
+result*
+
+dist-newstyle/

--- a/modules/templates/_haskell/LICENSE
+++ b/modules/templates/_haskell/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 Bastian Asmussen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/modules/templates/_haskell/README.md
+++ b/modules/templates/_haskell/README.md
@@ -1,0 +1,22 @@
+# Haskell Project Template
+
+This project is built using [Nix](https://nixos.org).
+
+## Getting Started
+
+- Enter the development shell with `nix develop`.
+- Run `cabal build` to compile.
+
+## Usage
+
+### Building
+
+```sh
+cabal build
+```
+
+### Running
+
+```sh
+cabal run
+```

--- a/modules/templates/_haskell/flake.nix
+++ b/modules/templates/_haskell/flake.nix
@@ -7,7 +7,11 @@
   outputs = inputs @ {flake-parts, ...}:
     flake-parts.lib.mkFlake {inherit inputs;} {
       systems = ["x86_64-linux"];
-      perSystem = {pkgs, ...}: {
+      perSystem = {pkgs, ...}: let
+        haskellPackages = pkgs.haskellPackages;
+      in {
+        packages.default = haskellPackages.callCabal2nix "sample-project" ./. {};
+
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             ghc

--- a/modules/templates/_haskell/flake.nix
+++ b/modules/templates/_haskell/flake.nix
@@ -1,0 +1,23 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs @ {flake-parts, ...}:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux"];
+      perSystem = {pkgs, ...}: {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            ghc
+            cabal-install
+            haskell-language-server
+            haskellPackages.hoogle
+            haskellPackages.hlint
+            haskellPackages.ormolu
+          ];
+        };
+      };
+    };
+}

--- a/modules/templates/_haskell/sample-project.cabal
+++ b/modules/templates/_haskell/sample-project.cabal
@@ -1,0 +1,14 @@
+cabal-version:   3.0
+name:            sample-project
+version:         0.1.0.0
+license:         MIT
+license-file:    LICENSE
+author:          Bastian Asmussen
+maintainer:      bastian@asmussen.tech
+build-type:      Simple
+
+executable sample-project
+    main-is:       Main.hs
+    hs-source-dirs: src
+    default-language: Haskell2010
+    build-depends: base >=4.7 && <5

--- a/modules/templates/_haskell/src/Main.hs
+++ b/modules/templates/_haskell/src/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "Hello, World!"

--- a/modules/templates/templates.nix
+++ b/modules/templates/templates.nix
@@ -1,6 +1,40 @@
 {
   flake.templates = rec {
     default = rust;
+    c = {
+      path = ./_c;
+      description = "C development environment.";
+      welcomeText = ''
+        # C Project Template
+
+        ## Intended Usage
+
+        Development of C programs and libraries.
+
+        ## Getting Started
+
+        - Enter the development shell with `nix develop`.
+        - Run `cmake -B build && cmake --build build` to compile.
+      '';
+    };
+
+    csharp = {
+      path = ./_csharp;
+      description = "C# development environment.";
+      welcomeText = ''
+        # C# Project Template
+
+        ## Intended Usage
+
+        Development of C# programs and libraries.
+
+        ## Getting Started
+
+        - Enter the development shell with `nix develop`.
+        - Run `dotnet new console -n MyProject` to scaffold a new project.
+      '';
+    };
+
     go = {
       path = ./_go;
       description = "Go development environment.";
@@ -18,6 +52,23 @@
         I highly recommend giving Adam Hoese's
         [gomod2nix blog post](https://www.tweag.io/blog/2021-03-04-gomod2nix) a
         read before continuing.
+      '';
+    };
+
+    haskell = {
+      path = ./_haskell;
+      description = "Haskell development environment.";
+      welcomeText = ''
+        # Haskell Project Template
+
+        ## Intended Usage
+
+        Development of Haskell programs and libraries.
+
+        ## Getting Started
+
+        - Enter the development shell with `nix develop`.
+        - Run `cabal build` to compile.
       '';
     };
 


### PR DESCRIPTION
- Add C, C#, and Haskell flake templates
- Add Colemak-DH with home-row mods for Delta via kanata
- Enable OSC 52 clipboard in Neovim for SSH paste buffer support
- Fix nvim-dap runner selection by adding default LLDB configurations
- Add impermanence module to persist state across reboots
- Fix LUKS boot on fresh installs (systemd initrd, dm-crypt, USB drivers)
- Enhance Linux hardening (kptr_restrict, dmesg_restrict, ptrace scope, core dumps, slab hardening, firewall)
- Add SSH GPG agent forwarding for YubiKey usage on remote machines
- Update TODO.md to reflect completed items