### PR TITLE
fix: resolve harpoon/tmux-navigator keybind overlap

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,7 @@ around problems.
 ## Neovim Plugins
 
 - [x] Resolved `harpoon` / `tmux-navigator` keybind overlap (`<C-j>`, `<C-k>`,
-  `<C-l>`). Harpoon slots moved to `<leader>1-4`.
+  `<C-l>`). Harpoon slots moved to `<C-S-j/k/l/m>`.
 
 ## Development Environments
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,11 +12,8 @@ around problems.
 
 ## Neovim Plugins
 
-The `harpoon` and `tmux-navigator` plugins have overlapping keybinds:
-
-- `<C-j>`
-- `<C-k>`
-- `<C-l>`
+- [x] Resolved `harpoon` / `tmux-navigator` keybind overlap (`<C-j>`, `<C-k>`,
+  `<C-l>`). Harpoon slots moved to `<leader>1-4`.
 
 ## Development Environments
 

--- a/modules/homeManagerModules/_nixvim-config.nix
+++ b/modules/homeManagerModules/_nixvim-config.nix
@@ -288,21 +288,21 @@
       '';
     })
 
-    (mapKey "n" "<leader>1" {
+    (mapKey "n" "<C-S-j>" {
       __raw = ''
         function()
           require('harpoon'):list():select(1)
         end
       '';
     })
-    (mapKey "n" "<leader>2" {
+    (mapKey "n" "<C-S-k>" {
       __raw = ''
         function()
           require('harpoon'):list():select(2)
         end
       '';
     })
-    (mapKey "n" "<leader>3" {
+    (mapKey "n" "<C-S-l>" {
       __raw = ''
         function()
           require('harpoon'):list():select(3)
@@ -310,7 +310,7 @@
       '';
     })
 
-    (mapKey "n" "<leader>4" {
+    (mapKey "n" "<C-S-m>" {
       __raw = ''
         function()
           require('harpoon'):list():select(4)

--- a/modules/homeManagerModules/_nixvim-config.nix
+++ b/modules/homeManagerModules/_nixvim-config.nix
@@ -288,21 +288,21 @@
       '';
     })
 
-    (mapKey "n" "<C-j>" {
+    (mapKey "n" "<leader>1" {
       __raw = ''
         function()
           require('harpoon'):list():select(1)
         end
       '';
     })
-    (mapKey "n" "<C-k>" {
+    (mapKey "n" "<leader>2" {
       __raw = ''
         function()
           require('harpoon'):list():select(2)
         end
       '';
     })
-    (mapKey "n" "<C-l>" {
+    (mapKey "n" "<leader>3" {
       __raw = ''
         function()
           require('harpoon'):list():select(3)
@@ -310,7 +310,7 @@
       '';
     })
 
-    (mapKey "n" "<C-m>" {
+    (mapKey "n" "<leader>4" {
       __raw = ''
         function()
           require('harpoon'):list():select(4)


### PR DESCRIPTION
## Summary

Harpoon and tmux-navigator both bind `<C-j>`, `<C-k>`, and `<C-l>`, so one always shadows the other. This moves harpoon slot selection to `<leader>1-4`, freeing `<C-h/j/k/l>` entirely for tmux pane navigation.

| Before | After | Action |
|---|---|---|
| `<C-j>` | `<leader>1` | Harpoon slot 1 |
| `<C-k>` | `<leader>2` | Harpoon slot 2 |
| `<C-l>` | `<leader>3` | Harpoon slot 3 |
| `<C-m>` | `<leader>4` | Harpoon slot 4 |

`<leader>1-4` are unused and the slot number maps directly to the key, so no muscle memory tax.

## Test plan

- [ ] Verify `<C-j/k/l>` navigate tmux panes without triggering harpoon
- [ ] Verify `<leader>1-4` select harpoon slots correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)