### PR TITLE
chore: update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1051,11 +1051,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Why

Master nixpkgs broke evaluation for hosts that pin \`boot.kernelPackages\` to a kernel set whose \`nvidiaPackages.<variant>\` is the already-built kernel module (e.g. \`nix-cachyos-kernel\`) rather than the wrapper exposing a \`.mod\` passthru. Concretely, evaluating \`nixosConfigurations.epsilon\` against any current \`nixos-unstable\` commit fails with:

\`\`\`
error: attribute 'mod' missing
at nixos/modules/hardware/video/nvidia.nix:818:85:
   818 | extraModulePackages = if useOpenModules then [ nvidia_x11.open ] else [ nvidia_x11.mod ];
\`\`\`

Root cause: the breaking commit is upstream nixpkgs [\`c7dfcad\`](https://github.com/NixOS/nixpkgs/commit/c7dfcad894b8) (\"linuxPackages.nvidia-x11: separate proprietary kernel modules\"), which started referencing \`nvidia_x11.mod\` in the NixOS module. Hosts using overlay-based kernel packages (cachyos) get a \`cfg.package\` that doesn't expose that passthru.

## What

Pin \`nixpkgs.url\` to [\`consoleBeep/nixpkgs#fix/nvidia-mod-fallback\`](https://github.com/consoleBeep/nixpkgs/tree/fix/nvidia-mod-fallback), which is upstream master HEAD (\`61a7520db583\`) plus a single-line change:

\`\`\`diff
-extraModulePackages = if useOpenModules then [ nvidia_x11.open ] else [ nvidia_x11.mod ];
+extraModulePackages = if useOpenModules then [ nvidia_x11.open ] else [ (nvidia_x11.mod or nvidia_x11) ];
\`\`\`

Falls back to \`nvidia_x11\` itself when the \`.mod\` passthru is absent, restoring compatibility with kernel package overlays without changing behaviour on stock nixpkgs.

## Verified

Sandboxed Docker container (linux/amd64), \`nix eval --impure '.#nixosConfigurations.<host>.config.system.build.toplevel.drvPath'\`:

| Host    | Result |
|---------|--------|
| delta   | ok     |
| epsilon | ok     |
| eta     | ok     |
| mu      | ok     |
| iso     | ok     |

\`nix-secrets\` was stubbed locally for evaluation since the real one is a private SSH-only repo on Codeberg.

## Test plan

- [ ] \`nix flake check --all-systems\` on a real builder
- [ ] \`nh os switch\` on epsilon (the cachyos+nvidia case the patch addresses)
- [ ] \`nh os switch\` on delta (sanity, no nvidia)

🤖 Generated with [Claude Code](https://claude.com/claude-code)