### PR TITLE
feat: add noctalia idleEnabled toggle and C/Haskell templates

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -29,6 +29,6 @@ to implement a template for each language I use, which, as of now consists of:
 - [x] Rust
 - [x] Go
 - [ ] C#
-- [ ] Haskell
-- [ ] C
+- [x] Haskell
+- [x] C
 - [x] Python

--- a/modules/templates/_c/LICENSE
+++ b/modules/templates/_c/LICENSE
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) 2026 Bastian Asmussen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+

--- a/modules/templates/_c/Makefile
+++ b/modules/templates/_c/Makefile
@@ -1,0 +1,9 @@
+CC := gcc
+CFLAGS := -O2 -Wall -Wextra -Wpedantic -std=c11
+
+sample-project: main.c
+	$(CC) $(CFLAGS) -o $@ $<
+
+.PHONY: clean
+clean:
+	rm -f sample-project

--- a/modules/templates/_c/README.md
+++ b/modules/templates/_c/README.md
@@ -1,0 +1,11 @@
+# C Project Template
+
+## Intended Usage
+
+Development of C programs and libraries.
+
+## Getting Started
+
+- Enter the development shell with `nix develop`.
+- Build with `make` or `nix build`.
+- Rename `sample-project` in `Makefile` and `flake.nix` to your project name.

--- a/modules/templates/_c/flake.nix
+++ b/modules/templates/_c/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "C development environment.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs =
+    inputs@{
+      flake-parts,
+      ...
+    }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" ];
+      perSystem =
+        { pkgs, ... }:
+        {
+          packages.default = pkgs.stdenv.mkDerivation {
+            pname = "sample-project";
+            version = "0.1.0";
+            src = ./.;
+
+            installPhase = ''
+              install -Dm755 sample-project $out/bin/sample-project
+            '';
+          };
+
+          devShells.default = pkgs.mkShell {
+            packages = with pkgs; [
+              gcc
+              gnumake
+              gdb
+              clang-tools
+              valgrind
+            ];
+          };
+        };
+    };
+}

--- a/modules/templates/_c/main.c
+++ b/modules/templates/_c/main.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(void) {
+    puts("Hello, World!");
+    return 0;
+}

--- a/modules/templates/_haskell/LICENSE
+++ b/modules/templates/_haskell/LICENSE
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) 2026 Bastian Asmussen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+

--- a/modules/templates/_haskell/README.md
+++ b/modules/templates/_haskell/README.md
@@ -1,0 +1,11 @@
+# Haskell Project Template
+
+## Intended Usage
+
+Development of Haskell programs and libraries.
+
+## Getting Started
+
+- Enter the development shell with `nix develop`.
+- Build with `cabal build` or `nix build`.
+- Rename `sample-project` in `sample-project.cabal` and `flake.nix` to your project name.

--- a/modules/templates/_haskell/app/Main.hs
+++ b/modules/templates/_haskell/app/Main.hs
@@ -1,0 +1,4 @@
+module Main where
+
+main :: IO ()
+main = putStrLn "Hello, World!"

--- a/modules/templates/_haskell/flake.nix
+++ b/modules/templates/_haskell/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "Haskell development environment.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs =
+    inputs@{
+      flake-parts,
+      ...
+    }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" ];
+      perSystem =
+        { pkgs, ... }:
+        let
+          hp = pkgs.haskellPackages;
+          pkg = hp.callCabal2nix "sample-project" ./. { };
+        in
+        {
+          packages.default = pkg;
+
+          devShells.default = hp.shellFor {
+            packages = _: [ pkg ];
+            nativeBuildInputs = with hp; [
+              cabal-install
+              haskell-language-server
+              ghcid
+            ];
+          };
+        };
+    };
+}

--- a/modules/templates/_haskell/sample-project.cabal
+++ b/modules/templates/_haskell/sample-project.cabal
@@ -1,0 +1,13 @@
+cabal-version: 2.4
+name:          sample-project
+version:       0.1.0.0
+synopsis:      Sample Haskell project.
+license:       MIT
+build-type:    Simple
+
+executable sample-project
+  main-is:          Main.hs
+  hs-source-dirs:   app
+  build-depends:    base >=4.14 && <5
+  default-language: Haskell2010
+  ghc-options:      -Wall

--- a/modules/templates/templates.nix
+++ b/modules/templates/templates.nix
@@ -1,6 +1,25 @@
 {
   flake.templates = rec {
     default = rust;
+
+    c = {
+      path = ./_c;
+      description = "C development environment.";
+      welcomeText = ''
+        # C Project Template
+
+        ## Intended Usage
+
+        Development of C programs and libraries.
+
+        ## Getting Started
+
+        - Enter the development shell with `nix develop`.
+        - Build with `make` or `nix build`.
+        - Rename `sample-project` in `Makefile` and `flake.nix` to your project name.
+      '';
+    };
+
     go = {
       path = ./_go;
       description = "Go development environment.";
@@ -18,6 +37,24 @@
         I highly recommend giving Adam Hoese's
         [gomod2nix blog post](https://www.tweag.io/blog/2021-03-04-gomod2nix) a
         read before continuing.
+      '';
+    };
+
+    haskell = {
+      path = ./_haskell;
+      description = "Haskell development environment.";
+      welcomeText = ''
+        # Haskell Project Template
+
+        ## Intended Usage
+
+        Development of Haskell programs and libraries.
+
+        ## Getting Started
+
+        - Enter the development shell with `nix develop`.
+        - Build with `cabal build` or `nix build`.
+        - Rename `sample-project` in `sample-project.cabal` and `flake.nix` to your project name.
       '';
     };
 

--- a/modules/wrappedPrograms/noctalia.nix
+++ b/modules/wrappedPrograms/noctalia.nix
@@ -8,10 +8,18 @@
       ...
     }:
     {
-      options.videoDir = lib.mkOption {
-        type = lib.types.str;
-        default = "/home/${inputs.nix-secrets.user.name}/Videos";
-        description = "Directory noctalia's screen recorder writes to.";
+      options = {
+        videoDir = lib.mkOption {
+          type = lib.types.str;
+          default = "/home/${inputs.nix-secrets.user.name}/Videos";
+          description = "Directory noctalia's screen recorder writes to.";
+        };
+
+        idleEnabled = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Whether the idle service turns off displays and locks the session after the configured timeouts.";
+        };
       };
 
       config = {
@@ -293,7 +301,7 @@
           };
 
           idle = {
-            enabled = true;
+            enabled = config.idleEnabled;
             screenOffTimeout = 300;
             lockTimeout = 330;
             suspendTimeout = 0;


### PR DESCRIPTION
## Summary

Addresses two of the three open items in `TODO.md`:

- **noctalia idle toggle** — Exposes `idle.enabled` as an `idleEnabled` option on the `noctalia-shell` wrapper module (default `true`, preserves current behavior). One knob, no per-host wiring yet — the wrapper still builds a single shared package via `packages.noctalia-shell`, so flipping this is global. Per-host (epsilon-only) requires either package variants or a runtime toggle; happy to follow up once you've picked an approach.
- **C and Haskell flake templates** — Mirror the existing `_rust` / `_go` / `_python` style:
  - C: `stdenv.mkDerivation` + Makefile, devShell with `gcc gnumake gdb clang-tools valgrind`.
  - Haskell: `haskellPackages.callCabal2nix` + minimal `.cabal` and `Main.hs`, devShell with `cabal-install haskell-language-server ghcid`.

## Not in this PR

- **Undotree** — `opts.undofile = true` is already set (line 69 of `_nixvim-config.nix`) and `.local/state/nvim` is already in epsilon's persistence list (line 206). The setup looks correct as-is. Need your exact symptom (does `~/.local/state/nvim/undo/` exist after a session? does \`:set undofile?\` show on?) before any change is defensible.
- **C# template** — Skipped. \`buildDotnetModule\` needs a \`deps.json\` that must be generated from real project content; it can't ship as a static template.

## Verification

- \`nix eval .#nixosConfigurations.{delta,epsilon,eta,mu}.config.system.build.toplevel.drvPath\` — all four produce a \`.drv\` path (Docker container, \`nix-secrets\` overridden with a local stub).
- \`nix eval .#templates --apply builtins.attrNames\` → \`[ \"c\" \"default\" \"go\" \"haskell\" \"python\" \"rust\" ]\`.
- \`nixfmt --check\`, \`statix check\`, \`deadnix --fail\` — all clean on the changed files.
- Templates are **not** flake-locked in this PR — \`flake.lock\` files get generated on first \`nix flake init\` + \`nix flake update\` by the consumer.

## Alternatives considered

- For noctalia, considered flipping \`idle.enabled = false\` globally instead of adding a toggle. Rejected — that changes behavior on delta/eta too. Toggle preserves the current default.
- For the templates, considered \`flake-utils\` (like \`_go\`) or bare \`genAttrs\` (like \`_python\`). Went with \`flake-parts\` to match \`_rust\` since it matches the top-level flake's framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)